### PR TITLE
問題文に沿うようにgetPassengersに変更

### DIFF
--- a/tests/Station14/Question/CarTest.php
+++ b/tests/Station14/Question/CarTest.php
@@ -44,9 +44,9 @@ class CarTest extends TestCase
     /**
      * @test
      */
-    public function getPassenger_passengerの数を表示する(): void
+    public function getPassengers_passengerの数を表示する(): void
     {
-        $method = new ReflectionMethod($this->car, 'getPassenger');
+        $method = new ReflectionMethod($this->car, 'getPassengers');
         $method->setAccessible(true);
 
         $this->expectOutputString(0);


### PR DESCRIPTION
### Why

問題文に沿うようにテストコードを改修したいです。
`getPassenger` -> `getPassengers`

[Laravel - PHP基礎編 | Station14 クラス内で定数を定義しよう](https://techtrain.dev/mypage/railway/28/station/695)

> $passengerの数をechoで表示するgetPassengersメソッド
> $passengerの人数が1増え、getPassengersを実行するpickupメソッド

### What

`getPassenger` -> `getPassengers` に変更

### QA

ローカル環境でテストがクリアすることを確認しました。

```sh
php-stations on  station18 [!] via 🐘 v8.1.32
❯ docker compose exec php-container vendor/bin/phpunit tests/Station14
WARN[0000] /home/yoshikawa/ghq/github.com/yoshikawa/php-stations/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

........                                                            8 / 8 (100%)

Time: 00:00.003, Memory: 6.00 MB

OK (8 tests, 8 assertions)
```